### PR TITLE
Add shape comment for some tensors and remove 2 'for' loops

### DIFF
--- a/hmlstm/hmlstm_cell.py
+++ b/hmlstm/hmlstm_cell.py
@@ -99,15 +99,15 @@ class HMLSTMCell(rnn_cell_impl.RNNCell):
 
         new_c: [B, h_l]
         '''
-        z = tf.squeeze(z, axis=[1])                                 # [B]
-        zb = tf.squeeze(zb, axis=[1])                               # [B]
+        z = tf.squeeze(z, axis=[1])                           # [B]
+        zb = tf.squeeze(zb, axis=[1])                         # [B]
         new_c = tf.where(
-            tf.equal(z, tf.constant(1., dtype=tf.float32)),         # [B]
-            tf.multiply(i, g, name='c'),                            # [B, h_l]
+            tf.equal(z, tf.constant(1., dtype=tf.float32)),   # [B]
+            tf.multiply(i, g, name='c'),                      # [B, h_l], flush
             tf.where(
                 tf.equal(zb, tf.constant(0., dtype=tf.float32)),    # [B]
-                tf.identity(c),                                     # [B, h_l]
-                tf.add(tf.multiply(f, c), tf.multiply(i, g))        # [B, h_l]
+                tf.identity(c),                               # [B, h_l], copy
+                tf.add(tf.multiply(f, c), tf.multiply(i, g))  # [B, h_l], update
             )
         )
         return new_c  # [B, h_l]

--- a/hmlstm/hmlstm_cell.py
+++ b/hmlstm/hmlstm_cell.py
@@ -92,7 +92,6 @@ class HMLSTMCell(rnn_cell_impl.RNNCell):
     def calculate_new_cell_state(self, c, g, i, f, z, zb):
         '''
         update c and h according to correct operations
-        must do each batch independently
 
         c, g, i, f: [B, h_l]
         z, zb: [B, 1]

--- a/hmlstm/hmlstm_network.py
+++ b/hmlstm/hmlstm_network.py
@@ -210,7 +210,8 @@ class HMLSTMNetwork(object):
 
     def split_out_cell_states(self, accum):
         '''
-        accum: [B, sum(h_l)]
+        accum: [B, H], i.e. [B, sum(h_l) * 2 + num_layers]
+
 
         cell_states: a list of ([B, h_l], [B, h_l], [B, 1]), with length L
         '''

--- a/hmlstm/hmlstm_network.py
+++ b/hmlstm/hmlstm_network.py
@@ -259,9 +259,10 @@ class HMLSTMNetwork(object):
             # [B, I] + [B, sum(ha_l)] -> [B, I + sum(ha_l)]
             hmlstm_in = array_ops.concat((elem, h_aboves), axis=1)
             _, state = hmlstm(hmlstm_in, cell_states)
-
+            # a list of (c=[B, h_l], h=[B, h_l], z=[B, 1]) ->
+            # a list of [B, h_l + h_l + 1]
             concated_states = [array_ops.concat(tuple(s), axis=1) for s in state]
-            return array_ops.concat(concated_states, axis=1)
+            return array_ops.concat(concated_states, axis=1)    # [B, H]
         # denote 'elem_len' as 'H'
         elem_len = (sum(self._hidden_state_sizes) * 2) + self._num_layers
         initial = tf.zeros([batch_size, elem_len])              # [B, H]

--- a/hmlstm/multi_hmlstm_cell.py
+++ b/hmlstm/multi_hmlstm_cell.py
@@ -49,7 +49,7 @@ class MultiHMLSTMCell(rnn_cell_impl.RNNCell):
             with vs.variable_scope("cell_%d" % i):
                 cur_state = state[i]    # ([B, h_l], [B, h_l], [B, 1])
                 # i == 0: [B, I + 1] + [B, ha_l] -> [B, I + 1 + ha_l]
-                # i != 0: [B, ha_l + 1] + [B, ha_l] -> [B, ha_l + 1 + ha_l]
+                # i != 0: [B, hb_l + 1] + [B, ha_l] -> [B, hb_l + 1 + ha_l]
                 cur_inp = array_ops.concat(
                     [raw_inp, h_aboves[i]], axis=1, name='input_to_cell')
 

--- a/hmlstm/multi_hmlstm_cell.py
+++ b/hmlstm/multi_hmlstm_cell.py
@@ -23,26 +23,31 @@ class MultiHMLSTMCell(rnn_cell_impl.RNNCell):
         return self._cells[-1].output_size
 
     def call(self, inputs, state):
-        """Run this multi-layer cell on inputs, starting from state."""
+        """Run this multi-layer cell on inputs, starting from state.
+        inputs: [B, I + sum(ha_l)]
+        state: a list of ([B, h_l], [B, h_l], [B, 1]), with length L
+
+
+        """
 
         total_hidden_size = sum(c._h_above_size for c in self._cells)
 
         # split out the part of the input that stores values of ha
-        raw_inp = inputs[:, :-total_hidden_size]
-        raw_h_aboves = inputs[:, -total_hidden_size:]
+        raw_inp = inputs[:, :-total_hidden_size]                # [B, I]
+        raw_h_aboves = inputs[:, -total_hidden_size:]           # [B, sum(ha_l)]
 
         ha_splits = [c._h_above_size for c in self._cells]
         h_aboves = array_ops.split(value=raw_h_aboves,
                                    num_or_size_splits=ha_splits, axis=1)
 
-        z_below = tf.ones([tf.shape(inputs)[0], 1])
-        raw_inp = array_ops.concat([raw_inp, z_below], axis=1)
+        z_below = tf.ones([tf.shape(inputs)[0], 1])             # [B, 1]
+        raw_inp = array_ops.concat([raw_inp, z_below], axis=1)  # [B, I + 1]
 
         new_states = [0] * len(self._cells)
         for i, cell in enumerate(self._cells):
             with vs.variable_scope("cell_%d" % i):
-                cur_state = state[i]
-
+                cur_state = state[i]    # ([B, h_l], [B, h_l], [B, 1])
+                # [B, I + 1] + [B, ha_l] -> [B, I + 1 + ha_l]
                 cur_inp = array_ops.concat(
                     [raw_inp, h_aboves[i]], axis=1, name='input_to_cell')
 


### PR DESCRIPTION
## What this PR does:
- Add shape comment for some tensors and add some docstrings for some methods

These comments make the program more readable.

- Remove the for-loop in `calculate_new_cell_state` and `calculate_new_hidden_state` of `HMLSTMCell`

- Fix docstring for `train` method of `HMLSTMNetwork`

In the `train` method of `HMLSTMNetwork`, `batch_in`'s shape should be `[num_batches, batch_size, num_timesteps, input_size]` instead of `[num_batches, num_timesteps, batch_size, input_size]` 